### PR TITLE
Add links to the GPG signatures of the binaries

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -204,6 +204,13 @@ header ul li {
     margin-bottom: 0;
 }
 
+.sig {
+    font-size: .75rem;
+    line-height: 1.25rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    margin-bottom: .5rem;
+}
 
 
 /*NEWS*/

--- a/index.html
+++ b/index.html
@@ -47,11 +47,13 @@
                 <img src="assets/img/apple-logo.png" alt="Apple Logo">
                 <p class="title">MacOS</p>
                 <a class="button" href="/dist/2/OnionShare-2.pkg" data-l10n="for-macosx">Download for MacOS</a>
+                <p class="sig" data-l10n="mac-signature"><a href="/dist/2/OnionShare-2.pkg.asc" title="Signature for verifying the binary">GPG Signature</a> <a href="https://github.com/micahflee/onionshare/wiki/Verifying-Signatures" title="Instructions for verifying binaries with signatures">(what's this?)</a></p>
             </div>
             <div class="osPrimary">
                 <img src="assets/img/windows-logo.png" alt="Windows Logo">
                 <p class="title">Windows</p>
                 <a class="button" href="/dist/2/onionshare-2-setup.exe" data-l10n="for-windows">Download for Windows</a>
+                <p class="sig" data-l10n="windows-signature"><a href="/dist/2/onionshare-2-setup.exe.asc" title="Signature for verifying the binary">GPG Signature</a> <a href="https://github.com/micahflee/onionshare/wiki/Verifying-Signatures" title="Instructions for verifying binaries with signatures">(what's this?)</a></p>
             </div>
         </div>
         <div class="clearfix">


### PR DESCRIPTION
It would be good to have links to the GPG signatures of the MacOS and Windows binaries, on the page.

I add a 'what's this?' link for instructions, which links to a page on the wiki that I hastily wrote just now https://github.com/micahflee/onionshare/wiki/Verifying-Signatures (edits welcome). 

Once we have the website in Lektor we can of course integrate these instructions into the website in a better way.