### PR TITLE
#1052 Add link to Ubuntu 18.04 workaround install instructions

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,6 +75,9 @@
                 <p class="code">sudo add-apt-repository ppa:micahflee/ppa</p>
                 <p class="code">sudo apt update</p>
                 <p class="code">sudo apt install -y onionshare</p>
+                <p data-l10n="ubuntu-instructions-1804">Using Ubuntu 18.04? See <a
+                        href="https://github.com/micahflee/onionshare/wiki/How-Do-I-Install-Onionshare#problem-installing-due-to-python3-flask-httpauth-package-dependency">
+                        these instructions.</a></p>
             </div>
             <div class="osSecondary">
                 <img src="assets/img/fedora-logo.png" alt="Fedora Logo">


### PR DESCRIPTION
See https://github.com/micahflee/onionshare/issues/1052 - some users are not finding the workaround instructions to install on Ubuntu 18.04. Adding a link to the website in case it helps.

This might go away when we have snaps/flatpaks but I'm not sure how soon that will be.