### PR TITLE
Updates the download paths and other URLs to a relative path so that onion link doesn't point to a plainsite link

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,9 +52,9 @@
 					<div class="description">
 						<div class="icon large windows"></div>
 						<h3>Windows</h3>
-						<a role="button" class="btn" href="https://onionshare.org/dist/2.3.1/OnionShare-2.3.1.msi"
+						<a role="button" class="btn" href="/dist/2.3.1/OnionShare-2.3.1.msi"
 							rel="noopener noreferrer nofollow" target="_blank">Download</a>
-						<a class="meta" href="https://onionshare.org/dist/2.3.1/OnionShare-2.3.1.msi.asc"
+						<a class="meta" href="/dist/2.3.1/OnionShare-2.3.1.msi.asc"
 							rel="noopener noreferrer nofollow" target="_blank">Sig</a> <a class="meta"
 							href="https://docs.onionshare.org/2.3.1/en/install.html#verifying-pgp-signatures"
 							rel="noopener noreferrer nofollow" target="_blank">&#40;What's this?&#41;</a>
@@ -64,9 +64,9 @@
 					<div class="description">
 						<div class="icon large mac"></div>
 						<h3>MacOS</h3>
-						<a role="button" class="btn" href="https://onionshare.org/dist/2.3.1/OnionShare-2.3.1.dmg"
+						<a role="button" class="btn" href="/dist/2.3.1/OnionShare-2.3.1.dmg"
 							rel="noopener noreferrer nofollow" target="_blank">Download</a>
-						<a class="meta" href="https://onionshare.org/dist/2.3.1/OnionShare-2.3.1.dmg.asc"
+						<a class="meta" href="/dist/2.3.1/OnionShare-2.3.1.dmg.asc"
 							rel="noopener noreferrer nofollow" target="_blank">Sig</a> <a class="meta"
 							href="https://docs.onionshare.org/2.3.1/en/install.html#verifying-pgp-signatures"
 							rel="noopener noreferrer nofollow" target="_blank">&#40;What's this?&#41;</a>
@@ -205,7 +205,7 @@
 		</p>
 		<p>Like all software, OnionShare may contain bugs or vulnerabilities.</p>
 		<p>🧅 http://lldan5gahapx5k7iafb3s4ikijc4ni7gx5iywdflkba5y2ezyg6sjgyd.onion/ <a
-				href="https://onionshare.org/onion.txt" target="_blank" rel="noopener noreferrer nofollow">(proof)</a>
+				href="/onion.txt" target="_blank" rel="noopener noreferrer nofollow">(proof)</a>
 		</p>
 	</footer>
 


### PR DESCRIPTION
Ideally I would like the docs link to also take the user to the onion docs link rather than the plainsite doc link, but I am not sure there is a very clean way to do that without involving JS (which kind of defeats the purpose according to me since folks with high security in Tor browser will still end up in the plainsite doc link)